### PR TITLE
Add voice-unit-converter community ability

### DIFF
--- a/community/voice-unit-converter/README.md
+++ b/community/voice-unit-converter/README.md
@@ -1,0 +1,42 @@
+# Voice Unit Converter
+
+![Community](https://img.shields.io/badge/OpenHome-Community-orange?style=flat-square)
+![Author](https://img.shields.io/badge/Author-@samsonadmasu-lightgrey?style=flat-square)
+
+## What It Does
+A voice-powered unit converter that handles any conversion in natural language — cups to tablespoons, Fahrenheit to Celsius, ounces to grams, and more. Just ask and get the answer.
+
+## Suggested Trigger Words
+- "convert"
+- "unit converter"
+- "how many"
+- "conversion"
+
+## Setup
+No setup required. No external APIs or keys needed.
+
+## How It Works
+1. User triggers the ability with a hotword
+2. Ability asks what to convert
+3. User asks a conversion in natural language
+4. LLM processes the question and returns a short answer
+5. Ability speaks the result and asks "Anything else?"
+6. User can keep converting or say "stop" / "exit" / "done" to quit
+
+## Key SDK Functions Used
+- `speak()` — Text-to-speech output
+- `user_response()` — Listen for user input
+- `text_to_text_response()` — LLM text generation with system prompt
+- `resume_normal_flow()` — Return to Personality
+
+## Example Conversation
+> **User:** "convert"
+> **AI:** "Unit converter ready. What would you like to convert?"
+> **User:** "How many tablespoons in a cup?"
+> **AI:** "There are 16 tablespoons in a cup."
+> **AI:** "Anything else?"
+> **User:** "What's 200 grams in ounces?"
+> **AI:** "200 grams is about 7.05 ounces."
+> **AI:** "Anything else?"
+> **User:** "done"
+> **AI:** "Goodbye!"

--- a/community/voice-unit-converter/main.py
+++ b/community/voice-unit-converter/main.py
@@ -1,0 +1,87 @@
+import json
+import os
+from src.agent.capability import MatchingCapability
+from src.main import AgentWorker
+from src.agent.capability_worker import CapabilityWorker
+
+# =============================================================================
+# VOICE UNIT CONVERTER
+# A voice-powered unit converter. Ask any conversion in natural language
+# and get the answer instantly. No API needed — the LLM handles everything.
+# =============================================================================
+
+EXIT_WORDS = {"stop", "exit", "quit", "done", "cancel", "bye", "goodbye", "leave"}
+
+SYSTEM_PROMPT = (
+    "You are a unit converter. The user will ask you to convert between units. "
+    "Respond with ONLY the conversion result in one short sentence. "
+    "Do not explain the formula. Do not add disclaimers. Just give the answer. "
+    "Example: '200 grams is about 7 ounces.'"
+)
+
+
+class VoiceUnitConverterCapability(MatchingCapability):
+    worker: AgentWorker = None
+    capability_worker: CapabilityWorker = None
+
+    @classmethod
+    def register_capability(cls) -> "MatchingCapability":
+        with open(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+        ) as file:
+            data = json.load(file)
+        return cls(
+            unique_name=data["unique_name"],
+            matching_hotwords=data["matching_hotwords"],
+        )
+
+    def call(self, worker: AgentWorker):
+        self.worker = worker
+        self.capability_worker = CapabilityWorker(self.worker)
+        self.worker.session_tasks.create(self.run())
+
+    async def run(self):
+        try:
+            self.worker.editor_logging_handler.info("[VoiceUnitConverter] Ability started")
+
+            await self.capability_worker.speak(
+                "Unit converter ready. What would you like to convert?"
+            )
+
+            while True:
+                user_input = await self.capability_worker.user_response()
+
+                if not user_input:
+                    await self.capability_worker.speak(
+                        "I didn't catch that. What would you like to convert?"
+                    )
+                    continue
+
+                if any(word in user_input.lower() for word in EXIT_WORDS):
+                    await self.capability_worker.speak("Goodbye!")
+                    break
+
+                try:
+                    response = self.capability_worker.text_to_text_response(
+                        user_input, system_prompt=SYSTEM_PROMPT
+                    )
+                    await self.capability_worker.speak(response)
+                    await self.capability_worker.speak("Anything else?")
+                except Exception as e:
+                    self.worker.editor_logging_handler.error(
+                        f"[VoiceUnitConverter] LLM error: {e}"
+                    )
+                    await self.capability_worker.speak(
+                        "Sorry, I had trouble with that. Try again."
+                    )
+
+        except Exception as e:
+            self.worker.editor_logging_handler.error(
+                f"[VoiceUnitConverter] Unexpected error: {e}"
+            )
+            await self.capability_worker.speak(
+                "Something went wrong. Exiting unit converter."
+            )
+        finally:
+            self.worker.editor_logging_handler.info("[VoiceUnitConverter] Ability ended")
+            self.capability_worker.resume_normal_flow()

--- a/community/voice-unit-converter/main.py
+++ b/community/voice-unit-converter/main.py
@@ -1,8 +1,9 @@
 import json
 import os
+
 from src.agent.capability import MatchingCapability
-from src.main import AgentWorker
 from src.agent.capability_worker import CapabilityWorker
+from src.main import AgentWorker
 
 # =============================================================================
 # VOICE UNIT CONVERTER


### PR DESCRIPTION
## What does this Ability do?

Voice Unit Converter — a voice-powered unit converter that handles any conversion in natural language. Users ask conversions naturally ("How many tablespoons in a cup?") and get instant spoken answers. No API keys needed — the LLM handles all conversions.

## Suggested Trigger Words

- "convert"
- "unit converter"
- "how many"
- "conversion"

## Type

- [x] New community Ability
- [ ] Improvement to existing Ability
- [ ] Bug fix
- [ ] Documentation update

## External APIs

<!-- Does this Ability call any external APIs? List them and note if an API key is required. -->

- [x] No external APIs
- [ ] Uses external API(s): <!-- list them -->

## Testing

- [x] Tested in OpenHome Live Editor
- [x] All exit paths tested (said "stop", "exit", etc.)
- [x] Error scenarios tested (API down, bad input, etc.)

## Checklist

- [x] Files are in `community/my-ability-name/`
- [x] `main.py` follows SDK pattern (extends `MatchingCapability`, has `register_capability` + `call`)
- [x] `README.md` included with description, suggested triggers, and setup
- [x] `resume_normal_flow()` called on every exit path
- [x] No `print()` — using `editor_logging_handler`
- [x] No hardcoded API keys — using placeholders
- [x] No blocked imports (`redis`, `connection_manager`, `user_config`)
- [x] No `asyncio.sleep()` or `asyncio.create_task()` — using `session_tasks`
- [x] Error handling on all external calls

## Anything else?

Simple, clean ability that works great for hands-busy situations (cooking, working out). Uses try/finally to guarantee resume_normal_flow() is always called.
