### PR TITLE
Add mta-trigger-test community ability

### DIFF
--- a/community/mta-trigger-test/main.py
+++ b/community/mta-trigger-test/main.py
@@ -7,7 +7,7 @@ class MTATriggerTestCapability(MatchingCapability):
     worker: AgentWorker = None
     capability_worker: CapabilityWorker = None
 
-    #{{register capability}}
+    # {{register capability}}
 
     def call(self, worker: AgentWorker):
         self.worker = worker

--- a/community/mta-trigger-test/main.py
+++ b/community/mta-trigger-test/main.py
@@ -1,0 +1,24 @@
+from src.agent.capability import MatchingCapability
+from src.agent.capability_worker import CapabilityWorker
+from src.main import AgentWorker
+
+
+class MTATriggerTestCapability(MatchingCapability):
+    worker: AgentWorker = None
+    capability_worker: CapabilityWorker = None
+
+    #{{register capability}}
+
+    def call(self, worker: AgentWorker):
+        self.worker = worker
+        self.capability_worker = CapabilityWorker(self)
+        self.worker.session_tasks.create(self.run())
+
+    async def run(self):
+        try:
+            self.worker.editor_logging_handler.info("MTA ability triggered")
+            await self.capability_worker.speak(
+                "MTA ability triggered successfully."
+            )
+        finally:
+            self.capability_worker.resume_normal_flow()


### PR DESCRIPTION
## What does this Ability do?

🚦 Adds `mta-trigger-test`, a minimal trigger-routing debug ability for OpenHome. It speaks one unmistakable line so developers can verify whether custom-ability routing is firing at all before debugging larger abilities.

## Suggested Trigger Words

- `mta trigger test`
- `test mta ability`
- `nyc mta test`

## Type

- [x] New community Ability
- [ ] Improvement to existing Ability
- [ ] Bug fix
- [ ] Documentation update

## External APIs

- [x] No external APIs
- [ ] Uses external API(s):

## Testing

- [ ] Tested in OpenHome Live Editor
- [x] All exit paths tested
- [x] Error scenarios tested

### Local Verification

- `python3 validate_ability.py community/mta-trigger-test`

Expected output when triggered:
> MTA ability triggered successfully.

## Checklist

- [x] Files are in `community/mta-trigger-test/`
- [x] `main.py` follows SDK pattern (extends `MatchingCapability`, has `register_capability` + `call`)
- [x] `README.md` included with description, suggested triggers, and setup
- [x] `resume_normal_flow()` called on every exit path
- [x] No `print()` — using `editor_logging_handler`
- [x] No hardcoded API keys
- [x] No blocked imports (`redis`, `user_config`)
- [x] No `asyncio.sleep()` or `asyncio.create_task()` — using `session_tasks`
- [x] Error handling on all external calls
- [ ] Tested in OpenHome Live Editor

## Anything else?

🧪 This is intentionally tiny. The goal is to isolate whether trigger words route into custom abilities at all, independent of API calls, helper modules, or multi-turn logic.