### PR TITLE
Add Hermes Agent Bridge community ability

### DIFF
--- a/community/hermes-agent/README.md
+++ b/community/hermes-agent/README.md
@@ -1,0 +1,120 @@
+# Hermes Agent Bridge
+
+![Community](https://img.shields.io/badge/OpenHome-Community-orange?style=flat-square)
+![Author](https://img.shields.io/badge/Author-@r0b0tlab-lightgrey?style=flat-square)
+
+## What It Does
+
+Hermes Agent Bridge turns an OpenHome speaker into a voice front end for a local Hermes Agent install. It sends a spoken task through OpenHome's local command bridge, runs `hermes chat -q` on the linked computer, then reads back a short voice-friendly result.
+
+## Suggested Trigger Words
+
+- "ask Hermes"
+- "run Hermes"
+- "Hermes agent"
+- "send this to Hermes"
+
+## Setup
+
+1. Install Hermes Agent on the computer connected to OpenHome.
+
+   Linux, macOS, WSL2, or Android Termux:
+   ```bash
+   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+   source ~/.bashrc   # or source ~/.zshrc
+   ```
+
+   Windows PowerShell:
+   ```powershell
+   iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+   ```
+
+2. Configure Hermes and verify a normal chat works before using this Ability.
+
+   Fast path with Nous Portal:
+   ```bash
+   hermes setup --portal
+   hermes chat -q "Reply with: ready for OpenHome."
+   ```
+
+   If you use your own provider, run:
+   ```bash
+   hermes model
+   hermes chat -q "Reply with: ready for OpenHome."
+   ```
+
+3. Connect the OpenHome local command bridge on the same computer. This Ability uses `exec_local_command()`, so the local client must be running and connected with your OpenHome API key from `https://app.openhome.com/dashboard/settings`.
+
+4. Upload this folder to `https://app.openhome.com/dashboard/abilities` with Add Custom Ability.
+
+5. Set the suggested trigger words in the dashboard and test in Live Editor.
+
+## How It Works
+
+1. You say a trigger phrase such as "ask Hermes" plus the task.
+2. OpenHome captures the complete transcription.
+3. The Ability blocks obviously unsafe requests and asks for confirmation before tasks that may change the local system.
+4. The Ability checks `hermes --version` on the linked computer.
+5. The Ability runs `hermes chat -q <task>` through `exec_local_command()`.
+6. Hermes completes the task locally using its configured model, tools, skills, memory, and terminal backend.
+7. OpenHome rewrites the Hermes result into one or two spoken sentences and returns to normal flow.
+
+## Example Conversation
+
+> **User:** "ask Hermes to summarize the current git status in my project"
+> **OpenHome:** "Sending that to Hermes. This may take a minute."
+> **OpenHome:** "Hermes says your branch is clean and up to date."
+
+> **User:** "run Hermes and push my latest code"
+> **OpenHome:** "That may change your local system. Should Hermes run it?"
+> **User:** "yes"
+> **OpenHome:** "Sending that to Hermes. This may take a minute."
+> **OpenHome:** "Hermes pushed the branch successfully."
+
+## Safety Behavior
+
+This Ability improves on the minimal OpenClaw-style pass-through by adding:
+
+- a Hermes availability check before dispatch;
+- confirmation for tasks involving deletes, installs, deploys, commits, pushes, payments, sends, or other local-system changes;
+- rejection for obviously unsafe requests such as drive wipes, credential theft, malware, and security bypasses;
+- shell-safe prompt quoting before calling `hermes chat -q`;
+- structured response parsing for `data`, `stdout`, `output`, `message`, and `error` responses;
+- short voice rewriting instead of speaking raw command output.
+
+## Troubleshooting
+
+### "Hermes is not available on the linked computer yet"
+
+Run these on the linked computer:
+
+```bash
+hermes --version
+hermes chat -q "Reply with: ready."
+```
+
+If those fail, finish Hermes setup first with `hermes setup --portal` or `hermes model`.
+
+### OpenHome does not reach the computer
+
+Keep the OpenHome local command bridge running. The Ability depends on `exec_local_command()` just like the Local and OpenClaw templates.
+
+### Hermes runs too long
+
+Increase `HERMES_TIMEOUT_SECONDS` in `main.py` for long research or coding tasks. Keep spoken prompts short so the voice interaction does not feel stuck.
+
+### Wrong computer receives the task
+
+Set `HERMES_TARGET_ID` in `main.py` to the target device identifier used by your local bridge.
+
+## Notes for Builders
+
+- Trigger words live in the OpenHome dashboard, not in code.
+- Do not create or edit `config.json`; OpenHome manages it.
+- Keep `# {{register capability}}` unchanged.
+- Keep `resume_normal_flow()` on every exit path.
+- Do not put Hermes API keys or provider keys in this Ability. Configure them inside the local Hermes install.
+
+## APIs Required
+
+No external API is called directly by this OpenHome Ability. Hermes may use whichever model provider and tools the user configured locally.

--- a/community/hermes-agent/main.py
+++ b/community/hermes-agent/main.py
@@ -1,0 +1,231 @@
+import json
+import shlex
+
+from src.agent.capability import MatchingCapability
+from src.agent.capability_worker import CapabilityWorker
+from src.main import AgentWorker
+
+HERMES_CHECK_COMMAND = "hermes --version"
+HERMES_TIMEOUT_SECONDS = 180.0
+HERMES_TARGET_ID = None
+
+EXIT_WORDS = (
+    "stop",
+    "exit",
+    "quit",
+    "cancel",
+    "never mind",
+    "no thanks",
+)
+
+REJECT_PHRASES = (
+    "rm -rf /",
+    "format disk",
+    "erase disk",
+    "wipe the drive",
+    "delete everything",
+    "disable security",
+    "steal credentials",
+    "exfiltrate",
+    "malware",
+    "ransomware",
+)
+
+CONFIRM_PHRASES = (
+    "delete",
+    "remove",
+    "overwrite",
+    "shutdown",
+    "restart",
+    "reboot",
+    "install",
+    "uninstall",
+    "update",
+    "upgrade",
+    "deploy",
+    "commit",
+    "push",
+    "merge",
+    "send",
+    "email",
+    "purchase",
+    "buy",
+    "payment",
+    "run command",
+    "execute command",
+    "modify files",
+    "change files",
+)
+
+VOICE_SUMMARY_SYSTEM_PROMPT = """
+You rewrite local Hermes Agent output for a voice speaker.
+Rules:
+- Use one or two short conversational sentences.
+- Say the outcome first.
+- Do not use markdown, bullets, code blocks, JSON, stack traces, or long paths.
+- If the task failed, say what to check next in plain language.
+""".strip()
+
+HERMES_TASK_PREFIX = """
+You are Hermes Agent, running from an OpenHome voice Ability.
+Complete the user's request using your normal tools and return a concise final result.
+If you cannot safely complete it, explain the blocker clearly.
+Keep the final answer suitable for a voice response.
+""".strip()
+
+
+class HermesAgentCapability(MatchingCapability):
+    worker: AgentWorker = None
+    capability_worker: CapabilityWorker = None
+
+    # Do not change the register capability tag.
+    # {{register capability}}
+
+    def call(self, worker: AgentWorker):
+        self.worker = worker
+        self.capability_worker = CapabilityWorker(self.worker)
+        self.worker.session_tasks.create(self.run())
+
+    async def run(self):
+        try:
+            user_request = await self.capability_worker.wait_for_complete_transcription()
+            user_request = (user_request or "").strip()
+
+            if not user_request:
+                await self.capability_worker.speak("What should I ask Hermes to do?")
+                user_request = await self.capability_worker.user_response()
+                user_request = (user_request or "").strip()
+
+            if not user_request:
+                await self.capability_worker.speak("I didn't catch a task for Hermes.")
+                return
+
+            if self._is_exit(user_request):
+                await self.capability_worker.speak("Okay, cancelled.")
+                return
+
+            risk = self._risk_level(user_request)
+            if risk == "reject":
+                await self.capability_worker.speak(
+                    "I can't send that request to a local agent safely."
+                )
+                return
+
+            if risk == "confirm":
+                confirmed = await self.capability_worker.run_confirmation_loop(
+                    "That may change your local system. Should Hermes run it?"
+                )
+                if not confirmed:
+                    await self.capability_worker.speak("Okay, I won't run it.")
+                    return
+
+            if not await self._hermes_is_available():
+                await self.capability_worker.speak(
+                    "Hermes is not available on the linked computer yet. Check setup."
+                )
+                return
+
+            await self.capability_worker.speak(
+                "Sending that to Hermes. This may take a minute."
+            )
+            hermes_result = await self._run_hermes(user_request)
+            spoken = self._summarize_for_voice(user_request, hermes_result)
+            await self.capability_worker.speak(spoken)
+        except Exception as err:
+            self.worker.editor_logging_handler.error(
+                f"Hermes Agent ability failed: {err}"
+            )
+            await self.capability_worker.speak(
+                "Something went wrong while talking to Hermes. Check the logs."
+            )
+        finally:
+            self.capability_worker.resume_normal_flow()
+
+    async def _hermes_is_available(self) -> bool:
+        try:
+            response = await self._exec_local(HERMES_CHECK_COMMAND, timeout=15.0)
+            text = self._response_text(response).lower()
+        except Exception as err:
+            self.worker.editor_logging_handler.error(
+                f"Hermes availability check failed: {err}"
+            )
+            return False
+
+        if not text:
+            return False
+        failure_markers = (
+            "command not found",
+            "not recognized",
+            "no such file",
+            "hermes: not found",
+        )
+        return not any(marker in text for marker in failure_markers)
+
+    async def _run_hermes(self, user_request: str) -> str:
+        prompt = f"{HERMES_TASK_PREFIX}\n\nUser request:\n{user_request}"
+        command = "hermes chat -q " + shlex.quote(prompt)
+        response = await self._exec_local(command, timeout=HERMES_TIMEOUT_SECONDS)
+        return self._response_text(response)
+
+    async def _exec_local(self, command: str, timeout: float):
+        if HERMES_TARGET_ID:
+            return await self.capability_worker.exec_local_command(
+                command,
+                target_id=HERMES_TARGET_ID,
+                timeout=timeout,
+            )
+        return await self.capability_worker.exec_local_command(
+            command,
+            timeout=timeout,
+        )
+
+    def _is_exit(self, text: str) -> bool:
+        lower = text.lower()
+        return any(word in lower for word in EXIT_WORDS)
+
+    def _risk_level(self, text: str) -> str:
+        lower = text.lower()
+        if any(phrase in lower for phrase in REJECT_PHRASES):
+            return "reject"
+        if any(phrase in lower for phrase in CONFIRM_PHRASES):
+            return "confirm"
+        return "safe"
+
+    def _response_text(self, response) -> str:
+        if isinstance(response, dict):
+            for key in ("data", "stdout", "output", "message", "error"):
+                value = response.get(key)
+                if value:
+                    if isinstance(value, (dict, list)):
+                        return json.dumps(value)
+                    return str(value)
+            return json.dumps(response)
+        return str(response or "")
+
+    def _summarize_for_voice(self, user_request: str, hermes_result: str) -> str:
+        raw = (hermes_result or "").strip()
+        if not raw:
+            return "Hermes finished, but didn't return a result."
+
+        prompt = (
+            "User asked OpenHome to delegate this to Hermes:\n"
+            f"{user_request}\n\n"
+            "Hermes returned:\n"
+            f"{raw[:3000]}\n\n"
+            "Rewrite the result for spoken voice."
+        )
+        try:
+            spoken = self.capability_worker.text_to_text_response(
+                prompt,
+                [],
+                VOICE_SUMMARY_SYSTEM_PROMPT,
+            )
+        except Exception as err:
+            self.worker.editor_logging_handler.error(
+                f"Hermes result summarization failed: {err}"
+            )
+            spoken = raw
+
+        cleaned = (spoken or raw).replace("```json", "").replace("```", "")
+        cleaned = " ".join(cleaned.split())
+        return cleaned[:600] or "Hermes finished."


### PR DESCRIPTION
## What does this Ability do?

Adds `community/hermes-agent`, a voice bridge that lets an OpenHome speaker delegate tasks to a local Hermes Agent install. It captures the user request, blocks obviously unsafe requests, confirms local-system-changing tasks, invokes `hermes chat -q` through `exec_local_command()`, then rewrites the result for short spoken output.

## Suggested Trigger Words

- "ask Hermes"
- "run Hermes"
- "Hermes agent"
- "send this to Hermes"

## Type

- [x] New community Ability
- [ ] Improvement to existing Ability
- [ ] Bug fix
- [ ] Documentation update

## External APIs

- [x] No external APIs called directly by the OpenHome Ability
- [ ] Uses external API(s):

Hermes itself may use whichever model provider/tools the user configured locally.

## Testing

- [ ] Tested in OpenHome Live Editor
- [ ] All exit paths tested (said "stop", "exit", etc.)
- [x] Error scenarios covered in code (missing task, local Hermes unavailable, rejected risky requests, local command exceptions)
- [x] Ran `python3 validate_ability.py community/hermes-agent/`
- [x] Ran `python3 -m py_compile community/hermes-agent/main.py`
- [x] Ran `flake8 community/hermes-agent/main.py --max-line-length=120 --ignore=E501,W503`
- [x] Verified changed files are only under `community/hermes-agent/`

Live Editor testing was not performed from this environment because it requires an OpenHome dashboard/device session.

## Checklist

- [x] Files are in `community/hermes-agent/`
- [x] `main.py` follows SDK pattern (extends `MatchingCapability`, has `register_capability` + `call`)
- [x] `README.md` included with description, suggested triggers, and setup
- [x] `resume_normal_flow()` called on every exit path via `finally`
- [x] No `print()` — using `editor_logging_handler`
- [x] No hardcoded API keys — Hermes/provider credentials stay in the local Hermes install
- [x] No blocked imports (`redis`, `user_config`)
- [x] No `asyncio.sleep()` or `asyncio.create_task()` — using `session_tasks.create()` only
- [x] Error handling on all external/local bridge calls

## Anything else?

This intentionally follows the contributor guide by adding a community Ability only. It is comparable to the OpenClaw pass-through template but adds availability checks, confirmation gates, shell-safe quoting, response normalization, and voice-focused summarization.
