### PR TITLE
feat: Add Universal Voice Interpreter community ability

### DIFF
--- a/community/voice-interpreter/.openhome.json
+++ b/community/voice-interpreter/.openhome.json
@@ -1,0 +1,5 @@
+{
+  "name": "voiceinterpreter",
+  "capability_id": null,
+  "template": "loop-template"
+}

--- a/community/voice-interpreter/README.md
+++ b/community/voice-interpreter/README.md
@@ -1,0 +1,52 @@
+# Universal Voice Interpreter
+
+![Community](https://img.shields.io/badge/OpenHome-Community-orange?style=flat-square)
+![Author](https://img.shields.io/badge/Author-Umar_Faizan-lightgrey?style=flat-square)
+
+## What It Does
+A dynamic, two-way translation bridge for multi-lingual households or hosting. It initiates a continuous conversational loop that alternates between any two target languages, acting as a fluid, near-zero-latency interpreter.
+
+## Suggested Trigger Words
+- "start translation"
+- "start interpreter"
+- "act as my translator"
+
+## Setup
+No external API keys are required. This ability uses the core OpenHome LLM routing capabilities.
+
+## How It Works
+1. The user speaks the trigger phrase.
+2. The agent asks which two languages to translate between.
+3. The user responds (e.g., "English and French").
+4. A continuous loop starts. The agent listens, automatically detects which of the two languages was spoken, translates it to the other language, and speaks it out loud.
+5. **IMPORTANT:** The loop continues indefinitely in order to provide a seamless interpreter experience. To stop the loop and exit back to the normal OpenHome agent, the user must explicitly say **"Stop translation"** or **"Exit"**.
+
+## Example Conversation (English & French Scenario)
+
+Imagine a scenario where two people are in a room and don't speak each other's language. Person One speaks English, and Person Two speaks French. The OpenHome DevKit speaker is sitting on the table between them.
+
+> **Person One:** "Start translation."
+> 
+> **DevKit Speaker:** "Translation mode starting. What two languages would you like to translate between?"
+> 
+> **Person One:** "English and French."
+> 
+> **DevKit Speaker:** "Perfect. I am now acting as an interpreter for English and French. You can begin speaking. Say 'Stop translation' at any time to exit."
+> 
+> **Person Two (in French):** "Bonjour, enchanté de vous rencontrer. Quel temps fait-il aujourd'hui?"
+> 
+> **DevKit Speaker (in English):** "Hello, nice to meet you. What is the weather like today?"
+> 
+> **Person One (in English):** "It is very sunny and warm outside!"
+> 
+> **DevKit Speaker (in French):** "Il fait très beau et chaud dehors!"
+> 
+> *(The loop continues seamlessly back and forth)*
+> 
+> **Person Two (in French):** "Parfait ! Allons nous promener."
+> 
+> **DevKit Speaker (in English):** "Perfect! Let's go for a walk."
+> 
+> **Person One:** "Stop translation."
+> 
+> **DevKit Speaker:** "Translation mode deactivated. Returning you to the normal agent."

--- a/community/voice-interpreter/main.py
+++ b/community/voice-interpreter/main.py
@@ -1,0 +1,65 @@
+from src.agent.capability import MatchingCapability
+from src.main import AgentWorker
+from src.agent.capability_worker import CapabilityWorker
+
+class VoiceInterpreterCapability(MatchingCapability):
+    worker: AgentWorker = None
+    capability_worker: CapabilityWorker = None
+
+    # {{register capability}}
+
+    def call(self, worker: AgentWorker):
+        self.worker = worker
+        self.capability_worker = CapabilityWorker(self)
+        self.worker.session_tasks.create(self.run())
+
+    async def run(self):
+        try:
+            self.worker.editor_logging_handler.info("Starting Universal Voice Interpreter")
+
+            # Ask for the languages dynamically
+            await self.capability_worker.speak("Translation mode starting. What two languages would you like to translate between?")
+            languages_input = await self.capability_worker.user_response()
+
+            # Ensure the user didn't instantly try to exit
+            if not languages_input or languages_input.strip().lower() in ["stop", "exit", "quit", "cancel", "stop translation"]:
+                self.worker.editor_logging_handler.info("User exited during language selection.")
+                await self.capability_worker.speak("Interpreter cancelled.")
+                self.capability_worker.resume_normal_flow()
+                return
+
+            self.worker.editor_logging_handler.info(f"Target languages string: {languages_input}")
+            await self.capability_worker.speak(f"Perfect. I am now acting as an interpreter for {languages_input}. You can begin speaking. Say 'Stop translation' at any time to exit.")
+
+            # The continuous translation loop
+            while True:
+                user_input = await self.capability_worker.user_response()
+
+                # Clean punctuation for the exit check
+                clean_input = user_input.lower().strip(" .!?,")
+
+                # Exit condition (the escape hatch)
+                if not clean_input or clean_input in ["stop translation", "stop", "exit", "quit", "cancel"]:
+                    self.worker.editor_logging_handler.info("User exited the translation loop.")
+                    await self.capability_worker.speak("Translation mode deactivated. Returning you to the normal agent.")
+                    break
+
+                # Log the input text
+                self.worker.editor_logging_handler.info(f"Translating: {user_input}")
+
+                # Use the OpenHome LLM to detect and translate dynamically
+                prompt = f"You are a real-time interpreter between the following two languages: {languages_input}. Detect the language of the provided text. If it is in the first language, translate it to the second language. If it is in the second language, translate it to the first language. ONLY output the final translated text, absolutely nothing else. Do not add conversational filler. Text: {user_input}"
+
+                # Fetch translated response
+                translated_text = self.capability_worker.text_to_text_response(prompt)
+
+                # Speak it aloud
+                await self.capability_worker.speak(translated_text)
+
+        except Exception as e:
+            self.worker.editor_logging_handler.error(f"Error in Voice Interpreter: {str(e)}")
+            await self.capability_worker.speak("Sorry, I encountered an error during translation. Deactivating.")
+        finally:
+            # Mandatory: Release control back to the core OpenHome Agent on every exit path
+            self.worker.editor_logging_handler.info("Resuming normal flow.")
+            self.capability_worker.resume_normal_flow()

--- a/community/voice-interpreter/main.py
+++ b/community/voice-interpreter/main.py
@@ -2,6 +2,7 @@ from src.agent.capability import MatchingCapability
 from src.main import AgentWorker
 from src.agent.capability_worker import CapabilityWorker
 
+
 class VoiceInterpreterCapability(MatchingCapability):
     worker: AgentWorker = None
     capability_worker: CapabilityWorker = None


### PR DESCRIPTION
## What does this Ability do?
A dynamic, two-way translation bridge that acts as a near-zero-latency interpreter. It asks the user which two languages to translate between, and then initiates a continuous while True loop to act as a seamless real-time translator between two people in the same room.

## Suggested Trigger Words
- start translation
- start interpreter
- act as my translator

<!-- List the hotwords you recommend for activating this Ability (users set these in the dashboard) -->
- 
- 


## Type
- [x] New community Ability
- [ ] Improvement to existing Ability
- [ ] Bug fix
- [ ] Documentation update

## External APIs
- [x] No external APIs
- [ ] Uses external API(s): 

## Testing
- [x] Tested in OpenHome Live Editor
- [x] All exit paths tested (said "stop", "exit", etc.)
- [x] Error scenarios tested (API down, bad input, etc.)

## Checklist
- [x] Files are in `community/my-ability-name/`
- [x] `main.py` follows SDK pattern (extends `MatchingCapability`, has `register_capability` + `call`)
- [x] `README.md` included with description, suggested triggers, and setup
- [x] `resume_normal_flow()` called on every exit path
- [x] No `print()` — using `editor_logging_handler`
- [x] No hardcoded API keys — using placeholders
- [x] No blocked imports (`redis`, `user_config`)
- [x] No `asyncio.sleep()` or `asyncio.create_task()` — using `session_tasks`
- [x] Error handling on all external calls
- [x] Tested in OpenHome Live Editor

## Anything else?
This uses the core OpenHome LLM routing capabilities. I also added explicit logic to clean punctuation (e.g., stripping `.` and `!`) from the speech-to-text response before checking the "stop translation" exit condition, ensuring the escape hatch is robust.
