### PR TITLE
Native template picker + scaffolding in the VS Code extension

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     name: Build distribution
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'cli-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,32 @@
+name: Publish VS Code Extension
+
+# Publishes the OpenHome VS Code extension (vscode-extension/) to the VS Code
+# Marketplace when a GitHub Release tagged `ext-v*` is published.
+# Requires a repository secret VSCE_PAT (Azure DevOps Personal Access Token with
+# Marketplace > Manage scope for the `openhome` publisher).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'ext-') }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vscode-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install deps
+        run: npm install
+      - name: Compile
+        run: npm run compile
+      - name: Publish to VS Code Marketplace
+        run: npx @vscode/vsce publish --no-dependencies -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "openhome-abilities",
   "displayName": "OpenHome Abilities",
   "description": "Manage OpenHome agents, abilities, voice calls and the local devkit bridge from a sidebar.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "openhome",
   "engines": {
     "vscode": "^1.85.0"
@@ -25,6 +25,16 @@
           "type": "string",
           "default": "",
           "description": "Working directory for CLI commands. Defaults to the first workspace folder."
+        },
+        "openhome.templatesRepo": {
+          "type": "string",
+          "default": "openhome-dev/abilities",
+          "description": "GitHub owner/repo to fetch ability templates from."
+        },
+        "openhome.templatesRef": {
+          "type": "string",
+          "default": "main",
+          "description": "Git ref (branch/tag) to fetch templates from."
         }
       }
     },
@@ -108,7 +118,7 @@
   "icon": "media/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openhome-com/abilities"
+    "url": "https://github.com/openhome-dev/abilities"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as api from "./api";
+import * as templates from "./templates";
 import { ensureCli, runInTerminal, runCliOrNotify } from "./cli";
 import { AccountProvider, AbilitiesProvider, ActionsProvider, LocalProvider, Node } from "./trees";
 
@@ -214,25 +215,65 @@ export function activate(context: vscode.ExtensionContext): void {
     await vscode.window.showTextDocument(doc, { preview: false });
   });
 
-  // Create / sync / push operate on local ability folders (scaffold + zip
-  // upload), which the Python CLI already handles — so these stay CLI-backed.
+  // Create is fully native: templates come from GitHub (no repo/CLI needed);
+  // the chosen template is downloaded and scaffolded locally. Push (upload) is
+  // still CLI-backed below.
   reg("openhome.create", async () => {
-    if (!(await ensureCli())) {
+    const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
+    if (!wsRoot) {
+      vscode.window.showErrorMessage("OpenHome: open a folder first to create an ability into it.");
       return;
     }
     const name = await vscode.window.showInputBox({
       title: "New ability name",
-      prompt: "lowercase-with-hyphens",
+      prompt: "lowercase-with-hyphens (this becomes the folder + class name)",
       ignoreFocusOut: true,
-      validateInput: (v) => (/^[a-z0-9-]+$/.test(v) ? undefined : "Use lowercase letters, numbers and hyphens."),
+      validateInput: (v) =>
+        /^[a-z][a-z0-9-]*$/.test(v) ? undefined : "Lowercase letters, numbers and hyphens; start with a letter.",
     });
     if (!name) {
       return;
     }
-    const out = await runCliOrNotify(["create", name, "--no-push"]);
-    if (out !== undefined) {
-      vscode.window.showInformationMessage(out.trim() || `Created ${name}.`);
+
+    let list: templates.Template[];
+    try {
+      list = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Window, title: "OpenHome: loading templates…" },
+        () => templates.listTemplates()
+      );
+    } catch (e) {
+      vscode.window.showErrorMessage(`OpenHome: couldn't load templates. ${e instanceof Error ? e.message : e}`);
+      return;
+    }
+    if (list.length === 0) {
+      vscode.window.showErrorMessage("OpenHome: no templates found.");
+      return;
+    }
+    const picked = await vscode.window.showQuickPick(
+      list.map((t) => ({
+        label: `$(file-code) ${t.name}`,
+        description: t.source === "official" ? "official example" : "template",
+        t,
+      })),
+      { title: "Choose a template", placeHolder: "Select a starting template", matchOnDescription: true, ignoreFocusOut: true }
+    );
+    if (!picked) {
+      return;
+    }
+
+    try {
+      const folder = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: `OpenHome: creating "${name}" from ${picked.t.name}…` },
+        () => templates.scaffold(picked.t, name, vscode.Uri.joinPath(wsRoot, "user"))
+      );
       abilities.refresh();
+      const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(folder, "main.py"));
+      await vscode.window.showTextDocument(doc, { preview: false });
+      vscode.window.showInformationMessage(
+        `OpenHome: created "${name}". Edit main.py, then use Push to upload it.`
+      );
+    } catch (e) {
+      vscode.window.showErrorMessage(`OpenHome: create failed. ${e instanceof Error ? e.message : e}`);
     }
   });
 

--- a/vscode-extension/src/templates.ts
+++ b/vscode-extension/src/templates.ts
@@ -1,0 +1,140 @@
+import * as vscode from "vscode";
+
+const DEFAULT_REPO = "openhome-dev/abilities";
+const DEFAULT_REF = "main";
+
+export interface Template {
+  name: string;
+  source: "template" | "official";
+  path: string; // repo path, e.g. "templates/basic-template"
+}
+
+function cfg(): { repo: string; ref: string } {
+  const c = vscode.workspace.getConfiguration("openhome");
+  return {
+    repo: c.get<string>("templatesRepo") || DEFAULT_REPO,
+    ref: c.get<string>("templatesRef") || DEFAULT_REF,
+  };
+}
+
+/** Call the GitHub Contents API for a repo path, returning the JSON entries. */
+async function ghContents(repoPath: string): Promise<any[]> {
+  const { repo, ref } = cfg();
+  const url = `https://api.github.com/repos/${repo}/contents/${repoPath}?ref=${ref}`;
+  const resp = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json", "User-Agent": "openhome-vscode" },
+  });
+  if (resp.status === 403) {
+    throw new Error("GitHub API rate limit reached — please try again in a few minutes.");
+  }
+  if (!resp.ok) {
+    throw new Error(`GitHub returned ${resp.status} for ${repoPath}`);
+  }
+  const data = await resp.json();
+  return Array.isArray(data) ? data : [];
+}
+
+/** List the available templates (templates/ + official/) for the dropdown. */
+export async function listTemplates(): Promise<Template[]> {
+  const out: Template[] = [];
+  for (const [dir, source] of [
+    ["templates", "template"],
+    ["official", "official"],
+  ] as const) {
+    try {
+      for (const e of await ghContents(dir)) {
+        if (e.type === "dir") {
+          out.push({ name: e.name, source, path: e.path });
+        }
+      }
+    } catch {
+      /* a missing folder shouldn't block the other */
+    }
+  }
+  return out;
+}
+
+/** Recursively collect a template's files as {relative path, raw download URL}. */
+async function collectFiles(repoPath: string, rel = ""): Promise<{ rel: string; url: string }[]> {
+  const files: { rel: string; url: string }[] = [];
+  for (const e of await ghContents(repoPath)) {
+    const childRel = rel ? `${rel}/${e.name}` : e.name;
+    if (e.type === "dir") {
+      files.push(...(await collectFiles(e.path, childRel)));
+    } else if (e.type === "file" && e.download_url) {
+      files.push({ rel: childRel, url: e.download_url });
+    }
+  }
+  return files;
+}
+
+const SKIP = new Set([".openhome.json", ".DS_Store"]);
+
+function toClassName(name: string): string {
+  return (
+    name
+      .split("-")
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+      .join("") + "Capability"
+  );
+}
+
+/** Rename the template's `class XxxCapability(MatchingCapability)` to match the new name. */
+async function renameCapabilityClass(mainPy: vscode.Uri, abilityName: string): Promise<void> {
+  let text: string;
+  try {
+    text = Buffer.from(await vscode.workspace.fs.readFile(mainPy)).toString("utf8");
+  } catch {
+    return;
+  }
+  const m = text.match(/class\s+(\w+)\s*\(\s*MatchingCapability\s*\)/);
+  if (!m) {
+    return;
+  }
+  const oldClass = m[1];
+  const newClass = toClassName(abilityName);
+  if (oldClass === newClass) {
+    return;
+  }
+  text = text.replace(new RegExp(`\\b${oldClass}\\b`, "g"), newClass);
+  await vscode.workspace.fs.writeFile(mainPy, Buffer.from(text, "utf8"));
+}
+
+/**
+ * Download a template into `destDir/<newName>` and rename its capability class.
+ * Pure GitHub + filesystem — no CLI or local repo needed. Returns the new folder.
+ */
+export async function scaffold(
+  tpl: Template,
+  newName: string,
+  destDir: vscode.Uri
+): Promise<vscode.Uri> {
+  const target = vscode.Uri.joinPath(destDir, newName);
+  let exists = true;
+  try {
+    await vscode.workspace.fs.stat(target);
+  } catch {
+    exists = false;
+  }
+  if (exists) {
+    throw new Error(`A folder named "${newName}" already exists.`);
+  }
+
+  const files = await collectFiles(tpl.path);
+  if (files.length === 0) {
+    throw new Error(`Template "${tpl.name}" has no files.`);
+  }
+  for (const f of files) {
+    if (SKIP.has(f.rel.split("/").pop() || "")) {
+      continue;
+    }
+    const resp = await fetch(f.url, { headers: { "User-Agent": "openhome-vscode" } });
+    if (!resp.ok) {
+      throw new Error(`Failed to download ${f.rel} (${resp.status}).`);
+    }
+    const bytes = new Uint8Array(await resp.arrayBuffer());
+    await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(target, f.rel), bytes);
+  }
+  await renameCapabilityClass(vscode.Uri.joinPath(target, "main.py"), newName);
+  return target;
+}


### PR DESCRIPTION
## Summary
Adds a native **Create Ability** flow to the extension:
- Fetches the template catalog from GitHub (`templates/` + `official/`) via the Contents API — the dropdown is always live, no extension release needed to add templates.
- Downloads the chosen template and scaffolds it locally (renames the capability class, opens main.py) — **no repo clone, no CLI, no Python required**.
- New settings: `openhome.templatesRepo`, `openhome.templatesRef`.

## Notes
- No CLI changes. Push (upload) remains CLI-backed for now.
- Tested end-to-end in an empty folder.