### PR TITLE
Fix validator UTF-8 output encoding

### DIFF
--- a/validate_ability.py
+++ b/validate_ability.py
@@ -209,11 +209,11 @@ def main():
 
     full_output = "\n".join(output_lines)
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(full_output)
 
     if summary_file:
-        with open(summary_file, "a") as f:
+        with open(summary_file, "a", encoding="utf-8") as f:
             f.write("## 🔍 Ability Validation Results\n\n")
             f.write("```\n")
             f.write(full_output)


### PR DESCRIPTION
# Fix validator UTF-8 output encoding

## Summary

`validate_ability.py` writes validation output that contains emoji, which can raise `UnicodeEncodeError` on Windows when the active default encoding is CP1252. This change explicitly writes both validation output destinations as UTF-8, preserving the existing output format while making it portable across Windows environments.

Fixes #301

## Changes

- Write `VALIDATION_OUTPUT` and `GITHUB_STEP_SUMMARY` content with explicit UTF-8 encoding.

## Testing

- `git diff --check` — passed.
- Attempted the following contained verification command, but it could not run because the local sandbox Docker daemon was unavailable: `sandbox-run "python -m py_compile validate_ability.py && tmpdir=$(mktemp -d) && mkdir -p \"$tmpdir/community/bad_ability\" && python validate_ability.py \"$tmpdir/community/bad_ability\" >/dev/null || test $? -eq 1; python -c \"from pathlib import Path; p = Path('validation_output.txt'); data = p.read_bytes(); assert b'\\xf0\\x9f\\x93\\x8b' in data; assert data.decode('utf-8')\"; rm -f validation_output.txt"` — blocked before execution with `Cannot connect to the Docker daemon`.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
