### PR TITLE
docs: point users to the CLI's Local Link bridge, deprecate old template

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Do not start from a blank file. Each template is a minimal, working scaffold for
 | [Send Email](templates/send-email) | Send email with attachments via `send_email()` | `main.py` |
 | [Read Write File](templates/read-write-file) | Persist data across sessions with file storage | `main.py` |
 | [OpenClaw](templates/openclaw) | Drive a local computer through OpenClaw | `main.py` |
-| [OpenHome Local Link](templates/openhome-local-link) | Turn speech into shell commands on a local machine | `main.py` |
+| ~~[OpenHome Local Link](templates/openhome-local-link)~~ _(deprecated, see below)_ | Turn speech into shell commands on a local machine | `main.py` |
 | [Smart Home](templates/smart-home) | Voice-control MQTT smart-home devices, an LLM picks the device and command | `main.py` |
 | [Alarm](templates/alarm) | A Skill and a daemon working together via shared files | `main.py` + `background.py` |
 
@@ -198,6 +198,11 @@ Do not start from a blank file. Each template is a minimal, working scaffold for
 | [DevKit Stats](templates/devkit-stats) | Report live DevKit telemetry by voice: CPU, memory, temperature, uptime | `main.py` + `devkit_functions.py` |
 
 > More detail on each template: [templates/README.md](templates/README.md)
+>
+> **Want shell commands on your own machine?** Skip the deprecated Local Link
+> template above — use the CLI's built-in bridge instead: `openhome local start`.
+> It auto-routes to a raw shell executor, Hermes, or OpenClaw, whichever you
+> have installed. See [cli/README.md](cli/README.md#local-link-run-requests-on-your-own-machine).
 
 ---
 
@@ -277,6 +282,17 @@ openhome delete my-skill                      # remove from account and local fo
 ```bash
 openhome push_to_community my-skill           # copy user/my-skill into community/, then validate
 ```
+
+**Run requests on your own machine.** The CLI also ships a Local Link bridge —
+this is the one bridge to use for local execution now, replacing the old
+[OpenHome Local Link template](templates/openhome-local-link):
+```bash
+openhome local start        # start the bridge in the background
+openhome local status       # is it running?
+openhome local logs         # stream requests and responses live
+```
+It auto-detects and routes each request to a raw shell executor, Hermes, or
+OpenClaw, whichever you have installed and running.
 
 Full command reference and the API contract: [cli/README.md](cli/README.md).
 

--- a/templates/openhome-local-link/README.md
+++ b/templates/openhome-local-link/README.md
@@ -2,6 +2,18 @@
 ![Community](https://img.shields.io/badge/OpenHome-Community-orange?style=flat-square)
 ![Template](https://img.shields.io/badge/Type-Template-blue?style=flat-square)
 
+> ⚠️ **Deprecated — use the CLI's built-in Local Link bridge instead.**
+> This template predates `openhome local` and asks you to download a standalone
+> `local_client.py` from an external link, which we no longer recommend running.
+> The [OpenHome CLI](../../cli) ships its own Local Link bridge — install the CLI
+> and run:
+> ```bash
+> openhome local start
+> ```
+> It auto-detects and routes to a raw shell executor, Hermes, or OpenClaw,
+> whichever you have available. See [cli/README.md](../../cli/README.md#local-link-run-requests-on-your-own-machine)
+> for the full guide. This template is kept for reference only and is not maintained.
+
 ## What This Is
 **This is a template ability** that connects OpenHome to your Mac terminal. Use voice commands to run terminal commands, check system status, manage files, and automate Mac workflows — all without OpenClaw.
 


### PR DESCRIPTION
## Summary
- Fixes the exact confusion from the team Slack thread: a teammate pointed a community member at `templates/openhome-local-link` via GitHub, unaware the CLI's `openhome local` bridge already supersedes it.
- The old template also tells users to download a `local_client.py` from an external Google Drive link to run on their machine — worth retiring on trust grounds alone, separate from the duplication.
- Root cause: root README lists the old template in the gallery with no pointer to the CLI, the old template has no deprecation notice, and the CLI section of the root README never mentioned `openhome local` at all.

## Changes
- `templates/openhome-local-link/README.md`: deprecation banner at the top pointing to `openhome local start` and the CLI docs.
- `README.md`: strike through the old template's gallery entry with a note, add a callout after the template table, and document `openhome local` in the CLI section (previously undocumented there).

Docs-only change, no code/behavior changes.

## Test plan
- [x] Rendered both README diffs locally to confirm links resolve (`../../cli`, `cli/README.md#local-link-run-requests-on-your-own-machine`)
- [ ] Team confirms this matches how you want Local Link/Hermes/OpenClaw discovery framed before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)