### PR TITLE
feat: Kids Math Duel — 2-player head-to-head voice math game for families

### DIFF
--- a/community/kids-math-duel/README.md
+++ b/community/kids-math-duel/README.md
@@ -1,0 +1,81 @@
+# Kids Math Duel
+
+![Community](https://img.shields.io/badge/OpenHome-Community-orange?style=flat-square)
+![Author](https://img.shields.io/badge/Author-@hasni1731996-lightgrey?style=flat-square)
+
+A head-to-head voice math game for two players. Siblings, parent vs. child, or any two people in the room — ten questions, five each, 8 seconds on the clock, and a steal mechanic that keeps both players locked in the whole time.
+
+## What Makes It Different
+
+| | `vibe-trivia` | `spelling-bee-coach` | Kids Math Duel |
+|---|---|---|---|
+| Players | 1 | 1 | **2 (head-to-head)** |
+| Question source | LLM-generated | Static word list | **Pure Python (no LLM per question)** |
+| Steal mechanic | No | No | **Yes — wrong answer = opponent can steal** |
+| Countdown timer | No | No | **Yes — 8-second soft countdown** |
+| Target audience | General | General | **Kids and families** |
+| Setup required | None | None | None |
+
+## Trigger Phrases
+
+- `math duel` / `maths duel`
+- `math game` / `math challenge` / `math battle`
+- `math quiz` / `maths quiz`
+- `times tables game`
+- `number duel`
+
+## How It Works
+
+1. **Setup** — Speaker collects two player names by voice, then asks difficulty
+2. **10 rounds** — Players alternate: 5 questions each
+3. **8-second soft timer** — Speaker says "Time's up!" if no answer arrives; no hard cutoff, next round starts when the player speaks
+4. **Steal mechanic** — Wrong answer or timeout? The other player gets to steal the point
+5. **Score after every round** — "Correct! 3 in a row! Score: Zara 4, Hassan 2."
+6. **Post-game debrief** — LLM writes a fun 2-sentence summary
+7. **Play again?** — Yes / no prompt, new difficulty if playing again
+
+## Difficulty Levels
+
+| Level | Operations | Number range |
+|---|---|---|
+| Easy | + and − | 1–20 |
+| Medium | +, −, and × | 1–12 (times tables) |
+| Hard | +, −, ×, and ÷ | 1–50 × and ÷ (whole numbers only) |
+
+Division always produces a whole-number answer — no remainders.
+
+## Example Session
+
+> **"Math duel"**
+> → "Math Duel! Two players, ten questions, winner takes all. Let's set it up."
+> → "What's player one's name?" → "Zara" → "Player one is Zara, right?" → "Yes"
+> → "What's player two's name?" → "Hassan" → confirmed
+> → "Easy, medium, or hard?" → "Medium"
+> → "Alright — Zara versus Hassan, medium difficulty. Ten questions, five each. Here we go!"
+>
+> → "Zara — What is 7 times 8?"
+> *(Zara answers)* "56"
+> → "Correct! Score: Zara 1, Hassan 0."
+>
+> → "Hassan — What is 9 times 6?"
+> *(Hassan answers)* "63"
+> → "The answer was 54. Zara — steal it! What is 9 times 6?"
+> *(Zara answers)* "54"
+> → "Steal! Zara grabs the point. Score: Zara 2, Hassan 0."
+>
+> *(10 questions later)*
+> → "Game over! Zara wins 7 to 3!"
+> → "Zara absolutely dominated — seven out of ten with a four-question streak. Hassan, better luck next time, but that steal attempt in round two showed real quick thinking!"
+> → "Want to play again?"
+
+## Setup
+
+No API keys. No external services. Works entirely with the built-in LLM and OpenHome's persistent storage.
+
+1. Upload this folder via the OpenHome Dashboard
+2. Add the trigger phrases above
+3. Gather two players and trigger
+
+## Author
+
+Muhammad Hassan

--- a/community/kids-math-duel/main.py
+++ b/community/kids-math-duel/main.py
@@ -1,0 +1,362 @@
+import random
+import re
+
+from src.agent.capability import MatchingCapability
+from src.agent.capability_worker import CapabilityWorker
+from src.main import AgentWorker
+
+STORAGE_KEY = "kids_math_duel_leaderboard"
+TOTAL_QUESTIONS = 10
+TIMER_SECONDS = 8
+
+EXIT_WORDS = {"stop", "quit", "exit", "end", "bye", "goodbye", "cancel"}
+EXIT_PHRASES = {"that's all", "all done", "never mind", "i'm done", "no thanks"}
+
+DIFFICULTY_CONFIG = {
+    "easy":   {"ops": ["+", "-"],                       "max_a": 20, "max_b": 20},
+    "medium": {"ops": ["+", "-", "times"],              "max_a": 12, "max_b": 12},
+    "hard":   {"ops": ["+", "-", "times", "divided"],   "max_a": 50, "max_b": 12},
+}
+
+DIFFICULTY_ALIASES = {
+    "easy": "easy", "simple": "easy", "beginner": "easy",
+    "medium": "medium", "normal": "medium", "middle": "medium",
+    "hard": "hard", "difficult": "hard", "advanced": "hard", "expert": "hard",
+}
+
+HOTWORDS = {
+    "math duel", "maths duel", "math game", "math challenge",
+    "math battle", "times tables game", "let's play math",
+    "math quiz", "maths quiz", "number duel",
+}
+
+
+class KidsMathDuel(MatchingCapability):
+    worker: AgentWorker = None
+    capability_worker: CapabilityWorker = None
+
+    # Do not change following tag of register capability
+    # {{register capability}}
+
+    _answered: bool = False
+    _timed_out: bool = False
+    _timer_epoch: int = 0
+    _current_opponent: str = ""
+
+    def does_match(self, text: str) -> bool:
+        t = text.lower()
+        return any(hw in t for hw in HOTWORDS)
+
+    def call(self, worker: AgentWorker):
+        self.worker = worker
+        self.capability_worker = CapabilityWorker(self.worker)
+        self.worker.session_tasks.create(self._run())
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    async def _run(self):
+        try:
+            trigger = (await self.capability_worker.wait_for_complete_transcription() or "").strip()
+            if self._is_exit(trigger):
+                await self.capability_worker.speak("No problem, see you next time!")
+                return
+
+            await self.capability_worker.speak(
+                "Math Duel! Two players, ten questions, winner takes all. Let's set it up."
+            )
+
+            p1 = await self._collect_player_name(1)
+            if p1 is None:
+                return
+
+            p2 = await self._collect_player_name(2)
+            if p2 is None:
+                return
+
+            difficulty = await self._choose_difficulty()
+            if difficulty is None:
+                return
+
+            await self.capability_worker.speak(
+                f"Alright — {p1} versus {p2}, {difficulty} difficulty. "
+                f"Ten questions, five each. You have {TIMER_SECONDS} seconds per question. Here we go!"
+            )
+
+            while True:
+                scores, best_streaks = await self._run_game(p1, p2, difficulty)
+                await self._announce_result(p1, p2, scores, best_streaks, difficulty)
+                self._update_leaderboard(p1, scores[p1], best_streaks[p1])
+                self._update_leaderboard(p2, scores[p2], best_streaks[p2])
+
+                play_again = await self.capability_worker.run_confirmation_loop("Want to play again?")
+                if not play_again:
+                    await self.capability_worker.speak("Great game! See you next time.")
+                    break
+
+                difficulty = await self._choose_difficulty()
+                if difficulty is None:
+                    break
+
+                await self.capability_worker.speak(
+                    f"Round two — {p1} versus {p2}, {difficulty}. Let's go!"
+                )
+
+        except Exception as e:
+            self.worker.editor_logging_handler.error(f"[KidsMathDuel] Error: {e}")
+        finally:
+            self.capability_worker.resume_normal_flow()
+
+    # ------------------------------------------------------------------
+    # Setup — names and difficulty
+    # ------------------------------------------------------------------
+
+    async def _collect_player_name(self, player_num: int) -> str | None:
+        label = "one" if player_num == 1 else "two"
+        default = f"Player {player_num}"
+
+        for _ in range(3):
+            await self.capability_worker.speak(f"What's player {label}'s name?")
+            raw = (await self.capability_worker.user_response() or "").strip()
+
+            if self._is_exit(raw):
+                await self.capability_worker.speak("Okay, bye!")
+                return None
+
+            name = raw.split()[0].capitalize() if raw else ""
+            if not name:
+                await self.capability_worker.speak("I didn't catch that. Try again.")
+                continue
+
+            confirmed = await self.capability_worker.run_confirmation_loop(
+                f"Player {label} is {name}, right?"
+            )
+            if confirmed:
+                return name
+
+        return default
+
+    async def _choose_difficulty(self) -> str | None:
+        await self.capability_worker.speak("Easy, medium, or hard?")
+
+        for attempt in range(3):
+            raw = (await self.capability_worker.user_response() or "").lower().strip()
+
+            if self._is_exit(raw):
+                await self.capability_worker.speak("Okay, bye!")
+                return None
+
+            for word, level in DIFFICULTY_ALIASES.items():
+                if word in raw:
+                    return level
+
+            if attempt < 2:
+                await self.capability_worker.speak("Say easy, medium, or hard.")
+
+        return "easy"
+
+    # ------------------------------------------------------------------
+    # Game loop
+    # ------------------------------------------------------------------
+
+    async def _run_game(self, p1: str, p2: str, difficulty: str) -> tuple:
+        players = [p1, p2]
+        scores = {p1: 0, p2: 0}
+        streaks = {p1: 0, p2: 0}
+        best_streaks = {p1: 0, p2: 0}
+
+        for q_num in range(TOTAL_QUESTIONS):
+            player = players[q_num % 2]
+            opponent = players[(q_num + 1) % 2]
+            question, correct = self._generate_question(difficulty)
+
+            got_it = await self._ask_with_timer(player, question, correct, opponent)
+
+            if got_it:
+                scores[player] += 1
+                streaks[player] += 1
+                streaks[opponent] = 0
+                best_streaks[player] = max(best_streaks[player], streaks[player])
+
+                streak_msg = f" {streaks[player]} in a row!" if streaks[player] > 1 else ""
+                await self.capability_worker.speak(
+                    f"Correct!{streak_msg} Score: {p1} {scores[p1]}, {p2} {scores[p2]}."
+                )
+            else:
+                streaks[player] = 0
+                await self.capability_worker.speak(f"{opponent} — steal it! {question}")
+                steal_input = (await self.capability_worker.user_response() or "").strip()
+
+                if self._check_answer(steal_input, correct):
+                    scores[opponent] += 1
+                    streaks[opponent] += 1
+                    best_streaks[opponent] = max(best_streaks[opponent], streaks[opponent])
+                    await self.capability_worker.speak(
+                        f"Steal! {opponent} grabs the point. "
+                        f"Score: {p1} {scores[p1]}, {p2} {scores[p2]}."
+                    )
+                else:
+                    streaks[opponent] = 0
+                    await self.capability_worker.speak(
+                        f"No steal. The answer was {correct}. "
+                        f"Score: {p1} {scores[p1]}, {p2} {scores[p2]}."
+                    )
+
+        return scores, best_streaks
+
+    # ------------------------------------------------------------------
+    # Per-question ask with soft countdown timer
+    # ------------------------------------------------------------------
+
+    async def _ask_with_timer(self, player: str, question: str, correct: int, opponent: str = "") -> bool:
+        self._answered = False
+        self._timed_out = False
+        self._current_opponent = opponent
+        self._timer_epoch += 1
+        epoch = self._timer_epoch
+
+        await self.capability_worker.speak(f"{player} — {question}")
+        self.worker.session_tasks.create(self._countdown(TIMER_SECONDS, epoch))
+
+        user_input = (await self.capability_worker.user_response() or "").strip()
+        self._answered = True
+
+        if self._timed_out:
+            return False
+        return self._check_answer(user_input, correct)
+
+    async def _countdown(self, seconds: int, epoch: int):
+        await self.worker.session_tasks.sleep(float(seconds))
+        if epoch == self._timer_epoch and not self._answered:
+            self._timed_out = True
+            handoff = f"{self._current_opponent} — steal it!" if self._current_opponent else "Next player!"
+            await self.capability_worker.speak(f"Time's up! {handoff}")
+
+    # ------------------------------------------------------------------
+    # End of game
+    # ------------------------------------------------------------------
+
+    async def _announce_result(
+        self,
+        p1: str,
+        p2: str,
+        scores: dict,
+        best_streaks: dict,
+        difficulty: str,
+    ):
+        s1, s2 = scores[p1], scores[p2]
+
+        if s1 > s2:
+            result_line = f"{p1} wins {s1} to {s2}"
+        elif s2 > s1:
+            result_line = f"{p2} wins {s2} to {s1}"
+        else:
+            result_line = f"It's a tie — {s1} all"
+
+        await self.capability_worker.speak(f"Game over! {result_line}!")
+
+        debrief = (self.capability_worker.text_to_text_response(
+            f"Math Duel result: {p1} scored {s1}, {p2} scored {s2}. "
+            f"{p1} best streak: {best_streaks[p1]}. {p2} best streak: {best_streaks[p2]}. "
+            f"Difficulty: {difficulty}. "
+            "Write a fun, energetic 2-sentence summary for kids. Celebrate the winner or the tie. "
+            "Add one funny or encouraging observation. First names only. No markdown. Under 40 words."
+        ) or "").strip()
+
+        if debrief:
+            await self.capability_worker.speak(debrief)
+
+    # ------------------------------------------------------------------
+    # Math question generator — pure Python, no LLM, no API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _generate_question(difficulty: str) -> tuple:
+        cfg = DIFFICULTY_CONFIG[difficulty]
+        op = random.choice(cfg["ops"])
+        max_a, max_b = cfg["max_a"], cfg["max_b"]
+
+        if op == "+":
+            a = random.randint(1, max_a)
+            b = random.randint(1, max_b)
+            return f"What is {a} plus {b}?", a + b
+
+        if op == "-":
+            a = random.randint(2, max_a)
+            b = random.randint(1, a)  # no negatives
+            return f"What is {a} minus {b}?", a - b
+
+        if op == "times":
+            a = random.randint(2, min(12, max_a))
+            b = random.randint(2, min(12, max_b))
+            return f"What is {a} times {b}?", a * b
+
+        # divided — guaranteed whole-number result
+        b = random.randint(2, 10)
+        ans = random.randint(2, 10)
+        return f"What is {b * ans} divided by {b}?", ans
+
+    # ------------------------------------------------------------------
+    # Answer checker — regex first, LLM fallback for word numbers
+    # ------------------------------------------------------------------
+
+    def _check_answer(self, user_input: str, correct: int) -> bool:
+        if not user_input:
+            return False
+
+        m = re.search(r'\b(\d+)\b', user_input)
+        if m:
+            return int(m.group(1)) == correct
+
+        # LLM fallback for spoken word numbers ("fourteen", "forty two")
+        extracted = (self.capability_worker.text_to_text_response(
+            f"The user said: '{user_input}'. "
+            "What number did they say? Reply with ONLY the digits. If no number, reply 0."
+        ) or "0").strip()
+        try:
+            return int(re.sub(r'\D', '', extracted) or "0") == correct
+        except ValueError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Leaderboard — get_single_key / create_key / update_key (sync)
+    # ------------------------------------------------------------------
+
+    def _update_leaderboard(self, name: str, score: int, best_streak: int):
+        try:
+            raw = self.capability_worker.get_single_key(STORAGE_KEY)
+            data = raw.get("value", raw) if raw else {}
+        except Exception:
+            data = {}
+
+        if not isinstance(data, dict):
+            data = {}
+
+        entry = data.get(name, {"best_score": 0, "best_streak": 0, "games_played": 0})
+        entry["games_played"] = entry.get("games_played", 0) + 1
+        entry["best_score"] = max(entry.get("best_score", 0), score)
+        entry["best_streak"] = max(entry.get("best_streak", 0), best_streak)
+        data[name] = entry
+
+        result = self.capability_worker.create_key(STORAGE_KEY, data)
+        if not (result or {}).get("success"):
+            try:
+                self.capability_worker.update_key(STORAGE_KEY, data)
+            except Exception as e:
+                self.worker.editor_logging_handler.error(
+                    f"[KidsMathDuel] Leaderboard save error: {e!r}"
+                )
+
+    # ------------------------------------------------------------------
+    # Exit detection — two-tier (exact match for short words, substring for phrases)
+    # ------------------------------------------------------------------
+
+    def _is_exit(self, text: str) -> bool:
+        if not text:
+            return False
+        t = text.lower().strip()
+        tokens = set(t.split())
+        if tokens & EXIT_WORDS:
+            return True
+        return any(phrase in t for phrase in EXIT_PHRASES)

--- a/community/kids-math-duel/main.py
+++ b/community/kids-math-duel/main.py
@@ -339,14 +339,14 @@ class KidsMathDuel(MatchingCapability):
         entry["best_streak"] = max(entry.get("best_streak", 0), best_streak)
         data[name] = entry
 
-        result = self.capability_worker.create_key(STORAGE_KEY, data)
-        if not (result or {}).get("success"):
-            try:
+        try:
+            result = self.capability_worker.create_key(STORAGE_KEY, data)
+            if not (result or {}).get("success"):
                 self.capability_worker.update_key(STORAGE_KEY, data)
-            except Exception as e:
-                self.worker.editor_logging_handler.error(
-                    f"[KidsMathDuel] Leaderboard save error: {e!r}"
-                )
+        except Exception as e:
+            self.worker.editor_logging_handler.error(
+                f"[KidsMathDuel] Leaderboard save error: {e!r}"
+            )
 
     # ------------------------------------------------------------------
     # Exit detection — two-tier (exact match for short words, substring for phrases)


### PR DESCRIPTION
## Summary

- First ability in the catalog targeting kids and families — a completely absent user segment across all 120+ abilities
- Head-to-head 2-player voice math game: 10 questions alternating (5 each), 8-second soft countdown, steal mechanic on wrong answers or timeouts
- Pure Python math generation — no LLM per question, zero latency between rounds

## What makes it different

| | `vibe-trivia` | `spelling-bee-coach` | Kids Math Duel |
|---|---|---|---|
| Players | 1 | 1 | **2 (head-to-head)** |
| Question source | LLM | Static word list | **Pure Python** |
| Steal mechanic | No | No | **Yes** |
| Countdown timer | No | No | **Yes — 8s soft** |
| Target audience | General | General | **Kids & families** |

## Implementation notes

**Timer (epoch counter):** `session_tasks.create()` launches the countdown in parallel while `user_response()` waits for input. An epoch counter (`_timer_epoch`) prevents a previous question's countdown from firing into the next question when the user answers quickly.

**Steal mechanic:** Wrong answer or timeout → opponent is asked the same question, without revealing the answer first. The answer is only spoken if the steal also fails.

**Difficulty tiers:**
- Easy: `+` and `−`, numbers 1–20
- Medium: `+`, `−`, `×`, times-tables range (1–12)
- Hard: `+`, `−`, `×`, `÷` (division always whole-number), up to 50×12

**Patterns followed:**
- `get_single_key` unwrap: `.get("value", raw)` ✅
- Storage upsert: `create_key` + success check → `update_key` ✅
- LLM guards: all `text_to_text_response()` calls wrapped in `(... or "")` ✅
- `resume_normal_flow()` in `finally` block ✅
- No `asyncio`, no `print()`, no hardcoded keys ✅

## Test plan

- [ ] Trigger with "math duel" → name collection → difficulty selection flows correctly
- [ ] 10 questions alternate between players (P1 Q1, P2 Q2, ...)
- [ ] Correct answer: score updates, streak increments, opponent streak resets
- [ ] Wrong answer: steal offered to opponent WITHOUT revealing the answer first; answer revealed only if steal also fails
- [ ] Timer fires after 8s: "Time's up! [Opponent] — steal it!" speaks; game moves to steal without hanging
- [ ] Fast answer (< 8s): countdown from Q1 does NOT fire during Q2
- [ ] Play-again loop: new difficulty can be chosen each round
- [ ] Exit words ("stop", "quit") exit cleanly at any prompt
- [ ] `validate_ability.py` ✅  `flake8` ✅